### PR TITLE
Put reusable types in a types/ folder

### DIFF
--- a/app/api/simplify-contract/route.ts
+++ b/app/api/simplify-contract/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { GoogleGenerativeAI, Part } from '@google/generative-ai';
 import { getApiKey, handleError } from '../utils';
+import { Content, SimplifyRequest } from '../../../types/api';
 
 const apiKey = getApiKey();
 const genAI = new GoogleGenerativeAI(apiKey);
@@ -106,18 +107,6 @@ const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 const MAX_RETRIES = 3;
 const BASE_DELAY = 500;
-
-interface Content {
-    inlineData?: {
-        data: string;
-        mimeType: string;
-    };
-    text?: string;
-}
-
-interface SimplifyRequest {
-    contractText: string;
-}
 
 async function generateWithRetry(content: Content[], retryCount = 0): Promise<string> {
     try {

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,11 @@
+export interface Content {
+    inlineData?: {
+        data: string;
+        mimeType: string;
+    };
+    text?: string;
+}
+
+export interface SimplifyRequest {
+    contractText: string;
+}


### PR DESCRIPTION
Add reusable types to a new `types/` folder.

* **Add `types/api.ts`**
  - Define the `Content` interface.
  - Define the `SimplifyRequest` interface.

* **Modify `app/api/simplify-contract/route.ts`**
  - Import `Content` and `SimplifyRequest` from `types/api.ts`.
  - Remove the local definitions of `Content` and `SimplifyRequest`.

